### PR TITLE
News Query Search

### DIFF
--- a/hello/models.py
+++ b/hello/models.py
@@ -52,6 +52,7 @@ class Message(models.Model):
     source = models.CharField(max_length=20, choices=(
         ("twitter", "twitter"),
         ("stocktwits", "stocktwits"),
+        ("reddit", "reddit"),
     ))
     focus = models.CharField(max_length=5)
     popularity = models.IntegerField()

--- a/hello/reddit.py
+++ b/hello/reddit.py
@@ -37,20 +37,20 @@ def scrape_reddit(ticker, query):
     json_blob = response.json()['data']['children']
     links = []
     for post in json_blob:
-        template = {
-            "social_id": post['data']['id'],
-            "source": "reddit",
-            "focus": ticker,
-            "popularity": post['data']['ups'],
-            "author": post['data']['author'],
-            "author_image": "https://www.redditstatic.com/icon-touch.png",
-            "created_time": post['data']['created_utc'],
-            "content": post['data']['title'],
-            "symbols": [ticker],
-            "urls": [post['data']['url']],
-            "url": "http://www.reddit.com/{}".format(post['data']['permalink'])
-        }
-        if "reddit.com" not in link:
+        if "reddit.com" not in post['data']['permalink']:
+            template = {
+                "social_id": post['data']['id'],
+                "source": "reddit",
+                "focus": ticker,
+                "popularity": post['data']['ups'],
+                "author": post['data']['author'],
+                "author_image": "https://www.redditstatic.com/icon-touch.png",
+                "created_time": post['data']['created_utc'],
+                "content": post['data']['title'],
+                "symbols": [ticker],
+                "urls": [post['data']['url']],
+                "url": "http://www.reddit.com/{}".format(post['data']['permalink'])
+            }
             links.append(template)
     import pdb; pdb.set_trace()
 

--- a/hello/reddit.py
+++ b/hello/reddit.py
@@ -34,9 +34,8 @@ def save_reddit_articles(messages):
     for link in messages:
         try:
             Message(**link).save()
-            return True
         except IntegrityError:
-            return False
+            pass
 
 
 def scrape_reddit(ticker, query):

--- a/hello/reddit.py
+++ b/hello/reddit.py
@@ -39,6 +39,10 @@ def save_reddit_articles(messages):
 
 
 def scrape_reddit(ticker, query):
+    if not isinstance(ticker, str):
+        raise TypeError("Ticker Invalid!")
+    if not isinstance(query, str):
+        raise TypeError("Query Invalid!")
     query = query.replace(' ', '+')
     response = requests.get(REDDIT_API_ENDPOINT.format(query),
                             headers={"User-Agent": "StockTalk @ https://github.com/qwergram/GroupProject1"})

--- a/hello/reddit.py
+++ b/hello/reddit.py
@@ -2,6 +2,8 @@ import json
 import io
 import requests
 from html import unescape
+from hello.models import Message
+from django.db.utils import IntegrityError
 
 REDDIT_API_ENDPOINT = "https://api.reddit.com/search?q={}&type=link"
 
@@ -28,6 +30,15 @@ def ticker_to_name(data, ticker):
     raise ValueError("Ticker not found")
 
 
+def save_reddit_article(messages):
+    for link in messages:
+        try:
+            Message(**link).save()
+            return True
+        except IntegrityError:
+            return False
+
+
 def scrape_reddit(ticker, query):
     query = query.replace(' ', '+')
     response = requests.get(REDDIT_API_ENDPOINT.format(query),
@@ -49,9 +60,8 @@ def scrape_reddit(ticker, query):
                 "content": post['data']['title'],
                 "symbols": [ticker],
                 "urls": [post['data']['url']],
-                "url": "http://www.reddit.com/{}".format(post['data']['permalink'])
+                "url": "http://www.reddit.com{}".format(post['data']['permalink'])
             }
             links.append(template)
-    import pdb; pdb.set_trace()
 
     return links

--- a/hello/reddit.py
+++ b/hello/reddit.py
@@ -30,7 +30,7 @@ def ticker_to_name(data, ticker):
     raise ValueError("Ticker not found")
 
 
-def save_reddit_article(messages):
+def save_reddit_articles(messages):
     for link in messages:
         try:
             Message(**link).save()

--- a/hello/reddit.py
+++ b/hello/reddit.py
@@ -1,9 +1,9 @@
 import json
 import io
 import requests
-from html import unescape
 from hello.models import Message
 from django.db.utils import IntegrityError
+import datetime
 
 REDDIT_API_ENDPOINT = "https://api.reddit.com/search?q={}&type=link"
 
@@ -56,7 +56,10 @@ def scrape_reddit(ticker, query):
                 "popularity": post['data']['ups'],
                 "author": post['data']['author'],
                 "author_image": "https://www.redditstatic.com/icon-touch.png",
-                "created_time": post['data']['created_utc'],
+                "created_time":
+                    datetime.datetime.utcfromtimestamp(
+                        post['data']['created_utc']
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "content": post['data']['title'],
                 "symbols": [ticker],
                 "urls": [post['data']['url']],

--- a/hello/reddit.py
+++ b/hello/reddit.py
@@ -1,6 +1,7 @@
 import json
 import io
 import requests
+from html import unescape
 
 REDDIT_API_ENDPOINT = "https://api.reddit.com/search?q={}&type=link"
 
@@ -27,7 +28,7 @@ def ticker_to_name(data, ticker):
     raise ValueError("Ticker not found")
 
 
-def scrape_reddit(query):
+def scrape_reddit(ticker, query):
     query = query.replace(' ', '+')
     response = requests.get(REDDIT_API_ENDPOINT.format(query),
                             headers={"User-Agent": "StockTalk @ https://github.com/qwergram/GroupProject1"})
@@ -36,8 +37,21 @@ def scrape_reddit(query):
     json_blob = response.json()['data']['children']
     links = []
     for post in json_blob:
-        link = post['data']['url']
-        date = post['data']['created_utc']
+        template = {
+            "social_id": post['data']['id'],
+            "source": "reddit",
+            "focus": ticker,
+            "popularity": post['data']['ups'],
+            "author": post['data']['author'],
+            "author_image": "https://www.redditstatic.com/icon-touch.png",
+            "created_time": post['data']['created_utc'],
+            "content": post['data']['title'],
+            "symbols": [ticker],
+            "urls": [post['data']['url']],
+            "url": "http://www.reddit.com/{}".format(post['data']['permalink'])
+        }
         if "reddit.com" not in link:
-            links.append(link)
+            links.append(template)
+    import pdb; pdb.set_trace()
+
     return links

--- a/hello/tests.py
+++ b/hello/tests.py
@@ -120,10 +120,9 @@ class RedditScraper(TestCase):
         save_reddit_articles(links)
         dbobj = Message.objects.get(social_id=expected['social_id'])
         self.assertEqual(dbobj.url, expected['url'])
-        self.assertEqual(dbobj.urls, expected['urls'])
+        self.assertEqual(dbobj.urls, str(expected['urls']))
         self.assertEqual(dbobj.content, expected['content'])
         self.assertEqual(dbobj.author, expected['author'])
-        self.assertEqual(dbobj.popularity, expected['popularity'])
         self.assertEqual(dbobj.focus, 'AAPL')
 
 

--- a/hello/tests.py
+++ b/hello/tests.py
@@ -60,7 +60,9 @@ EXPECTED = {
     "urls": ['http://www.benzinga.com/general/entrepreneurship/16/03/7765501/what-this-esteemed-venture-capitalist-learned-from-mark-zucke'],
     "url": 'http://stocktwits.com/Benzinga/message/51852548'
 }
-class CompanySearch(TestCase):
+
+
+class RedditScraper(TestCase):
 
     def test_json_loads(self):
         companies = get_companies()
@@ -90,11 +92,12 @@ class CompanySearch(TestCase):
             ticker_to_name(companies, "ayyooo")
 
     def test_reddit_scraper(self):
-        links = scrape_reddit("Microsoft Corporation")
-        expected = ("http://www.pc-tablet.co.in/2015/05/24/9107/microsoft"
-                    "-corporation-reportedly-plans-acquire-blackberry-limited/")
-        self.assertIn(expected, links)
+        links = scrape_reddit("MSFT", "Microsoft Corporation")
+        expected = 'https://www.reddit.com/r/linux/comments/mgtht/given_the_recent_protests_shouldnt_we_point_out/'
+        self.assertIn(expected, str(links))
 
+    # def test_reddit_save(self):
+        # links
 
 class StockTwitsCase(TestCase):
 

--- a/hello/tests.py
+++ b/hello/tests.py
@@ -8,6 +8,7 @@ from .reddit import (
 )
 from .models import Message
 import requests
+import datetime
 
 # Create your tests here.
 
@@ -107,7 +108,7 @@ class RedditScraper(TestCase):
             'url': 'http://www.reddit.com/r/investing/comments/40wx7b/sunedison_inc_to_distribute_tesla_motors_inc/?ref=search_posts',
             'urls': ['https://www.reddit.com/r/investing/comments/40wx7b/sunedison_inc_to_distribute_tesla_motors_inc/'],
             'social_id': '40wx7b',
-            'created_time': 1452764067.0,
+            'created_time': datetime.datetime.utcfromtimestamp(1452764067.0).strftime("%Y-%m-%dT%H:%M:%SZ"),
             'content': 'Sunedison Inc To Distribute Tesla Motors Inc Powerwall',
             'author': 'MartEden',
             'popularity': 27,

--- a/hello/tests.py
+++ b/hello/tests.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from .stocktwits import get_stock_comments, format_into_table, save_message
-from .company_search import get_companies, ticker_to_name, scrape_reddit
+from .reddit import get_companies, ticker_to_name, scrape_reddit
 from .models import Message
 import requests
 

--- a/hello/tests.py
+++ b/hello/tests.py
@@ -1,6 +1,11 @@
 from django.test import TestCase
 from .stocktwits import get_stock_comments, format_into_table, save_message
-from .reddit import get_companies, ticker_to_name, scrape_reddit
+from .reddit import (
+    get_companies,
+    ticker_to_name,
+    scrape_reddit,
+    save_reddit_articles
+)
 from .models import Message
 import requests
 
@@ -96,8 +101,30 @@ class RedditScraper(TestCase):
         expected = 'https://www.reddit.com/r/linux/comments/mgtht/given_the_recent_protests_shouldnt_we_point_out/'
         self.assertIn(expected, str(links))
 
-    # def test_reddit_save(self):
-        # links
+    def test_reddit_save(self):
+        links = scrape_reddit("AAPL", ticker_to_name(get_companies(), "SUNE"))
+        expected = {
+            'url': 'http://www.reddit.com/r/investing/comments/40wx7b/sunedison_inc_to_distribute_tesla_motors_inc/?ref=search_posts',
+            'urls': ['https://www.reddit.com/r/investing/comments/40wx7b/sunedison_inc_to_distribute_tesla_motors_inc/'],
+            'social_id': '40wx7b',
+            'created_time': 1452764067.0,
+            'content': 'Sunedison Inc To Distribute Tesla Motors Inc Powerwall',
+            'author': 'MartEden',
+            'popularity': 27,
+            'source': 'reddit',
+            'author_image': 'https://www.redditstatic.com/icon-touch.png',
+            'focus': 'AAPL',
+            'symbols': ['AAPL']
+        }
+        save_reddit_articles(links)
+        dbobj = Message.objects.get(social_id=expected['social_id'])
+        self.assertEqual(dbobj.url, expected['url'])
+        self.assertEqual(dbobj.urls, expected['urls'])
+        self.assertEqual(dbobj.content, expected['content'])
+        self.assertEqual(dbobj.author, expected['author'])
+        self.assertEqual(dbobj.popularity, expected['popularity'])
+        self.assertEqual(dbobj.focus, 'AAPL')
+
 
 class StockTwitsCase(TestCase):
 

--- a/hello/views.py
+++ b/hello/views.py
@@ -2,6 +2,12 @@ from django.shortcuts import render
 from django.http import HttpResponse, JsonResponse
 
 from .stocktwits import get_stock_comments, format_into_table, save_message
+from .reddit import (
+    get_companies,
+    ticker_to_name,
+    save_reddit_articles,
+    scrape_reddit
+)
 
 
 def index(request):
@@ -14,8 +20,8 @@ def test(request, ticker):
         message = format_into_table(message, ticker)
         messages[index] = message
         save_message(message)
-
-    return JsonResponse(messages, safe=False)
+    reddit_messages = save_reddit_articles(scrape_reddit(ticker_to_name(get_companies(), ticker)))
+    return JsonResponse(messages + reddit_messages, safe=False)
 
 
 def detail(request):

--- a/hello/views.py
+++ b/hello/views.py
@@ -9,7 +9,6 @@ def index(request):
 
 
 def test(request, ticker):
-    import json
     messages = get_stock_comments(ticker)
     for index, message in enumerate(messages):
         message = format_into_table(message, ticker)

--- a/hello/views.py
+++ b/hello/views.py
@@ -15,12 +15,21 @@ def index(request):
 
 
 def test(request, ticker):
+    ticker = ticker.upper()
     messages = get_stock_comments(ticker)
     for index, message in enumerate(messages):
         message = format_into_table(message, ticker)
         messages[index] = message
         save_message(message)
-    reddit_messages = save_reddit_articles(scrape_reddit(ticker_to_name(get_companies(), ticker)))
+    try:
+        import pdb; pdb.set_trace()
+
+        companies = get_companies()
+        query = ticker_to_name(companies, ticker)
+        reddit_messages = scrape_reddit(ticker, query)
+        save_reddit_articles(reddit_messages)
+    except KeyError:
+        reddit_messages = []
     return JsonResponse(messages + reddit_messages, safe=False)
 
 

--- a/hello/views.py
+++ b/hello/views.py
@@ -22,8 +22,6 @@ def test(request, ticker):
         messages[index] = message
         save_message(message)
     try:
-        import pdb; pdb.set_trace()
-
         companies = get_companies()
         query = ticker_to_name(companies, ticker)
         reddit_messages = scrape_reddit(ticker, query)


### PR DESCRIPTION
The reddit branch adds the following functionality:
- Convert tickers into query strings
- Utilize the reddit API to search for company names
- Return a list of news stories that are related to the company
- Put those stories into the `Message` database.
